### PR TITLE
New storage variable, broke out permission only

### DIFF
--- a/roles/storage/defaults/main.yml
+++ b/roles/storage/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 reset: "no"
+setup_storage: True

--- a/roles/storage/tasks/main.yml
+++ b/roles/storage/tasks/main.yml
@@ -1,44 +1,6 @@
 ---
-- name: Create XFS partitions
-  parted:
-    device: /dev/{{item}}
-    label: gpt
-    number: 1
-    part_type: primary
-    state: present
-  with_items: "{{ storage_devs }}"
-- name: Unmount filesystems
-  mount:
-    path: /srv/node/{{item}}1
-    state: absent
-  with_items: "{{ storage_devs }}"
-  when: reset == "yes"
-- name: Create XFS filesystems
-  filesystem:
-    fstype: xfs
-    dev: /dev/{{item}}1
-    force: "{{ reset }}"
-    opts: "-L {{item}}1"
-  with_items: "{{ storage_devs }}"
-- name: Create dirs for mounts
-  file:
-    path: /srv/node/{{item}}1
-    state: directory
-    mode: 0755
-    owner: root
-    group: root
-  with_items: "{{ storage_devs }}"
-- name: Mount filesystems
-  mount:
-    path: /srv/node/{{item}}1
-    src: "LABEL={{item}}1"
-    fstype: xfs
-    opts: "noatime,nodiratime,nobarrier"
-    state: mounted
-  with_items: "{{ storage_devs }}"
-- name: Set permissions of mounted dirs
-  file:
-    path: /srv/node/{{item}}1
-    owner: hummingbird
-    group: hummingbird
-  with_items: "{{ storage_devs }}"
+- include: setup_storage.yml
+  when: setup_storage
+  
+- include: set_permissions_only.yml
+  when: not setup_storage

--- a/roles/storage/tasks/set_permissions_only.yml
+++ b/roles/storage/tasks/set_permissions_only.yml
@@ -1,0 +1,6 @@
+---
+- name: Set permissions of mounted dirs
+  file:
+    path: /srv/node/
+    owner: hummingbird
+    group: hummingbird

--- a/roles/storage/tasks/set_permissions_only.yml
+++ b/roles/storage/tasks/set_permissions_only.yml
@@ -1,6 +1,7 @@
 ---
 - name: Set permissions of mounted dirs
   file:
-    path: /srv/node/
-    owner: hummingbird
-    group: hummingbird
+     path: /srv/node/{{item}}1
+     owner: hummingbird
+     group: hummingbird
+   with_items: "{{ storage_devs }}"

--- a/roles/storage/tasks/set_permissions_only.yml
+++ b/roles/storage/tasks/set_permissions_only.yml
@@ -4,4 +4,4 @@
      path: /srv/node/{{item}}1
      owner: hummingbird
      group: hummingbird
-   with_items: "{{ storage_devs }}"
+  with_items: "{{ storage_devs }}"

--- a/roles/storage/tasks/setup_storage.yml
+++ b/roles/storage/tasks/setup_storage.yml
@@ -1,0 +1,45 @@
+
+---
+- name: Create XFS partitions
+  parted:
+    device: /dev/{{item}}
+    label: gpt
+    number: 1
+    part_type: primary
+    state: present
+  with_items: "{{ storage_devs }}"
+- name: Unmount filesystems
+  mount:
+    path: /srv/node/{{item}}1
+    state: absent
+  with_items: "{{ storage_devs }}"
+  when: reset == "yes"
+- name: Create XFS filesystems
+  filesystem:
+    fstype: xfs
+    dev: /dev/{{item}}1
+    force: "{{ reset }}"
+    opts: "-L {{item}}1"
+  with_items: "{{ storage_devs }}"
+- name: Create dirs for mounts
+  file:
+    path: /srv/node/{{item}}1
+    state: directory
+    mode: 0755
+    owner: root
+    group: root
+  with_items: "{{ storage_devs }}"
+- name: Mount filesystems
+  mount:
+    path: /srv/node/{{item}}1
+    src: "LABEL={{item}}1"
+    fstype: xfs
+    opts: "noatime,nodiratime,nobarrier"
+    state: mounted
+  with_items: "{{ storage_devs }}"
+- name: Set permissions of mounted dirs
+  file:
+    path: /srv/node/{{item}}1
+    owner: hummingbird
+    group: hummingbird
+  with_items: "{{ storage_devs }}"


### PR DESCRIPTION
Created a new variable setup_storage (default = True)

Used the new variable to allow the option to just set the
necessary directory permissions to hummingbird:hummingbird or
take raw devices then create partion, format, mount and set
device permissions