### PR TITLE
HUM-524 Copy23fix

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,17 +33,24 @@
 - name: Download latest hummingbird binary
   get_url:
     url: "{{ hummingbird_binary_url.stdout }}"
-    dest: /usr/local/bin/hummingbird
+    dest: /tmp/hummingbirdbinary
     mode: 0755
     force: yes
   when: not hummingbird_binary_url|skipped
 - name: Download specific hummingbird binary
   get_url:
     url: "https://github.com/troubling/hummingbird/releases/download/{{hummingbird_version}}/hummingbird"
-    dest: /usr/local/bin/hummingbird
+    dest: /tmp/hummingbirdbinary
     mode: 0755
     force: yes
   when: hummingbird_binary_url|skipped
+- name: Move binary into place
+  copy:
+    remote_src: yes
+    src: /tmp/hummingbirdbinary
+    dest: /usr/local/bin/hummingbird
+    mode: 0755
+    force: yes
 - name: Create /etc/hummingbird
   file:
     path: /etc/hummingbird

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,27 +30,35 @@
   shell: curl -s https://api.github.com/repos/troubling/hummingbird/releases/latest | jq --raw-output '.assets[0] | .browser_download_url'
   when: hummingbird_version is not defined or hummingbird_version == ''
   register: hummingbird_binary_url
+- name: Create download tmp dir
+  tempfile:
+    state: directory
+  register: downloadtmpdir
 - name: Download latest hummingbird binary
   get_url:
     url: "{{ hummingbird_binary_url.stdout }}"
-    dest: /tmp/hummingbirdbinary
+    dest: "{{downloadtmpdir.path}}/hummingbird"
     mode: 0755
     force: yes
   when: not hummingbird_binary_url|skipped
 - name: Download specific hummingbird binary
   get_url:
     url: "https://github.com/troubling/hummingbird/releases/download/{{hummingbird_version}}/hummingbird"
-    dest: /tmp/hummingbirdbinary
+    dest: "{{downloadtmpdir.path}}/hummingbird"
     mode: 0755
     force: yes
   when: hummingbird_binary_url|skipped
 - name: Move binary into place
   copy:
     remote_src: yes
-    src: /tmp/hummingbirdbinary
+    src: "{{downloadtmpdir.path}}/hummingbird"
     dest: /usr/local/bin/hummingbird
     mode: 0755
     force: yes
+- name: Remove temp dir
+  file:
+    state: absent
+    path: "{{downloadtmpdir.path}}"
 - name: Create /etc/hummingbird
   file:
     path: /etc/hummingbird


### PR DESCRIPTION
In Ansible 2.3 get_url doesn't have the ability to replace an in use file. Instead use copy.

(Ansible 2.4 uses the same mechanism for get_url as it does for copy.)