### PR TITLE
HUM-800 Add tracing config to hansible

### DIFF
--- a/group_vars/hummingbird/hummingbird
+++ b/group_vars/hummingbird/hummingbird
@@ -88,3 +88,12 @@ hummingbird_version: "dev"
 
 # Default state of all nodes
 state: "up"
+
+# Opentracing config.
+#tracing_enabled: false
+#tracing_agent_host_port: "localhost:6831"
+#tracing_sampler_type: ratelimiting
+#tracing_sampler_param: 2.0
+#tracing_reporter_log_spans: false
+#tracing_enable_httptrace: true
+

--- a/roles/account-server/defaults/main.yml
+++ b/roles/account-server/defaults/main.yml
@@ -1,2 +1,8 @@
 account_disk_limit: "100/0"
 
+tracing_enabled: false
+tracing_agent_host_port: 127.0.0.1:6831
+tracing_sampler_type: ratelimiting
+tracing_sampler_param: 2.0
+tracing_reporter_log_spans: false
+tracing_enable_httptrace: true

--- a/roles/account-server/templates/etc/account-server.j2
+++ b/roles/account-server/templates/etc/account-server.j2
@@ -14,3 +14,13 @@ disk_limit = {{ account_disk_limit }}
 {% if account_port is defined or account_replicator_port is defined %}
 bind_port = {{ account_replicator_port | default(account_port + 500) }}
 {% endif %}
+
+{% if tracing_enabled %}
+[tracing]
+agent_host_port = {{ tracing_agent_host_port }}
+#disabled = false
+sampler_type = {{ tracing_sampler_type }}
+sampler_param = {{ tracing_sampler_param }}
+reporter_log_spans = {{ tracing_reporter_log_spans }}
+enable_httptrace = {{ tracing_enable_httptrace }}
+{% endif %}

--- a/roles/container-server/defaults/main.yml
+++ b/roles/container-server/defaults/main.yml
@@ -1,1 +1,8 @@
 container_disk_limit: "100/0"
+
+tracing_enabled: false
+tracing_agent_host_port: 127.0.0.1:6831
+tracing_sampler_type: ratelimiting
+tracing_sampler_param: 2.0
+tracing_reporter_log_spans: false
+tracing_enable_httptrace: true

--- a/roles/container-server/templates/etc/container-server.j2
+++ b/roles/container-server/templates/etc/container-server.j2
@@ -14,3 +14,13 @@ disk_limit = {{ container_disk_limit }}
 {% if container_port is defined or container_replicator_port is defined %}
 bind_port = {{ container_replicator_port | default(container_port + 500) }}
 {% endif %}
+
+{% if tracing_enabled %}
+[tracing]
+agent_host_port = {{ tracing_agent_host_port }}
+#disabled = false
+sampler_type = {{ tracing_sampler_type }}
+sampler_param = {{ tracing_sampler_param }}
+reporter_log_spans = {{ tracing_reporter_log_spans }}
+enable_httptrace = {{ tracing_enable_httptrace }}
+{% endif %}

--- a/roles/object-server/defaults/main.yml
+++ b/roles/object-server/defaults/main.yml
@@ -1,2 +1,9 @@
 object_disk_limit: "100/0"
 account_rate_limit: "100/0"
+
+tracing_enabled: false
+tracing_agent_host_port: 127.0.0.1:6831
+tracing_sampler_type: ratelimiting
+tracing_sampler_param: 2.0
+tracing_reporter_log_spans: false
+tracing_enable_httptrace: true

--- a/roles/object-server/templates/etc/object-server.j2
+++ b/roles/object-server/templates/etc/object-server.j2
@@ -17,3 +17,13 @@ bind_port = {{ object_replicator_port | default(object_port + 500) }}
 {% endif %}
 
 [object-auditor]
+
+{% if tracing_enabled %}
+[tracing]
+agent_host_port = {{ tracing_agent_host_port }}
+#disabled = false
+sampler_type = {{ tracing_sampler_type }}
+sampler_param = {{ tracing_sampler_param }}
+reporter_log_spans = {{ tracing_reporter_log_spans }}
+enable_httptrace = {{ tracing_enable_httptrace }}
+{% endif %}

--- a/roles/proxy-server/defaults/main.yml
+++ b/roles/proxy-server/defaults/main.yml
@@ -3,3 +3,10 @@ proxy_obfuscated_prefix: ""
 account_db_max_writes_per_sec: 100
 container_db_max_writes_per_sec: 100
 proxy_port: 8080
+
+tracing_enabled: false
+tracing_agent_host_port: 127.0.0.1:6831
+tracing_sampler_type: ratelimiting
+tracing_sampler_param: 2.0
+tracing_reporter_log_spans: false
+tracing_enable_httptrace: true

--- a/roles/proxy-server/templates/etc/proxy-server.j2
+++ b/roles/proxy-server/templates/etc/proxy-server.j2
@@ -62,3 +62,13 @@ container_db_max_writes_per_sec = {{ container_db_max_writes_per_sec }}
 [filter:staticweb]
 
 [filter:copy]
+
+{% if tracing_enabled %}
+[tracing]
+agent_host_port = {{ tracing_agent_host_port }}
+#disabled = false
+sampler_type = {{ tracing_sampler_type }}
+sampler_param = {{ tracing_sampler_param }}
+reporter_log_spans = {{ tracing_reporter_log_spans }}
+enable_httptrace = {{ tracing_enable_httptrace }}
+{% endif %}


### PR DESCRIPTION
Copy and pasted the [tracing] sections into each server conf template.
Used the same variables for each of them, assuming you won't want to
configure them separately. Put defaults in each role. Defaulted to no tracing.