### PR TITLE
HUM-882 Stop hbird services on reset

### DIFF
--- a/roles/storage/tasks/setup_storage.yml
+++ b/roles/storage/tasks/setup_storage.yml
@@ -13,6 +13,12 @@
     apt:
       name: xfsprogs
       state: latest
+  - name: Ensure Hummingbird is not running
+    systemd:
+      name: hummingbird-*
+      state: stopped
+    when: reset == "yes"
+    ignore_errors: yes
   - name: Create XFS partitions
     parted:
       device: /dev/{{device}}


### PR DESCRIPTION
Since we are manually calling umount to unmount the volumes on reset,
the most common reason for error is that the services are running.  This
*should* work for most cases.

If this turns out to be not enough, we can take the next drastic step
and call out to `fuser` to kill any processes accessing the volumes
before unmounting.